### PR TITLE
Typo causes "Public Courses" to link to invalid location

### DIFF
--- a/app/views/layouts/_common_left.html.erb
+++ b/app/views/layouts/_common_left.html.erb
@@ -106,4 +106,4 @@
 <% end %>
 
 <li class="nav-header">Public Courses</li>
-<li><%= link_to 'View public courses <i class="icon-share"></i>', :controller => '/public', :couse => nil, :assignment => nil %></li>
+<li><%= link_to 'View public courses <i class="icon-share"></i>', :controller => '/public', :course => nil, :assignment => nil %></li>


### PR DESCRIPTION
Clicking the "Public Courses" link directs to an invalid page if viewing a course
